### PR TITLE
Copied 2022 code for robot test

### DIFF
--- a/robot/2023/src/main/java/frc/robot/Robot.java
+++ b/robot/2023/src/main/java/frc/robot/Robot.java
@@ -2,103 +2,253 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
+// Sources for Team 6845 (Grommit) below.  Here be dragons.
+
 package frc.robot;
 
+import com.ctre.phoenix.motorcontrol.ControlMode;
+import com.ctre.phoenix.motorcontrol.can.TalonSRX;
+import com.ctre.phoenix.motorcontrol.can.VictorSPX;
+
+import edu.wpi.first.wpilibj.AddressableLED;
+import edu.wpi.first.wpilibj.AddressableLEDBuffer;
+import edu.wpi.first.wpilibj.DigitalOutput;
+import edu.wpi.first.wpilibj.Joystick;
 import edu.wpi.first.wpilibj.TimedRobot;
-import edu.wpi.first.wpilibj2.command.Command;
-import edu.wpi.first.wpilibj2.command.CommandScheduler;
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.cameraserver.CameraServer;
+import edu.wpi.first.cscore.UsbCamera;
+import edu.wpi.first.networktables.NetworkTableEntry;
+import edu.wpi.first.networktables.NetworkTableInstance;
 
 /**
- * The VM is configured to automatically run this class, and to call the functions corresponding to
- * each mode, as described in the TimedRobot documentation. If you change the name of this class or
- * the package after creating this project, you must also update the build.gradle file in the
- * project.
+ * Concrete implementation of the TimedRobot class for team 6845.
  */
 public class Robot extends TimedRobot {
-  private Command m_autonomousCommand;
+  private static final int LEFT_TRIGGER = 2;
+  private static final int RIGHT_TRIGGER = 3;
+  TalonSRX leftyA = new TalonSRX(0);
+  TalonSRX leftyB = new TalonSRX(1);
+  TalonSRX rightyA = new TalonSRX(2);
+  TalonSRX rightyB = new TalonSRX(3);
+  VictorSPX basket = new VictorSPX(4);
+  AddressableLED ledsT = new AddressableLED(0);
+  AddressableLEDBuffer ledBuffT = new AddressableLEDBuffer(30);
+  
+  DigitalOutput horn = new DigitalOutput(0);
 
-  private RobotContainer m_robotContainer;
+  int ltarget = 0;
+  int rtarget = 0;
+  int rout = 0;
+  int lout = 0;
+  int throttleStep = 1;
+  int throttle = 55;
+  int previousPov = 0;
+  int lcal = 0;
+  int rcal = 0;
+  int maxValue = 105;
+  int minValue = 5;
+  int changeInThrottle = 10;
+  int stickDirectlyLeft = 270;
+  int stickDirectlyRight = 90;
+
+  private final Joystick stick = new Joystick(0);
+  private final Timer m_timer = new Timer();
+
+  boolean reverse_triggered = false;
+  boolean is_reverse = false;
+  boolean STOP = false;
+
+  UsbCamera fronty;
+  UsbCamera reary;
+  NetworkTableEntry cam;
 
   /**
-   * This function is run when the robot is first started up and should be used for any
+   * This function is run when the robot is first started up and should be used
+   * for any
    * initialization code.
    */
   @Override
   public void robotInit() {
-    // Instantiate our RobotContainer.  This will perform all our button bindings, and put our
-    // autonomous chooser on the dashboard.
-    m_robotContainer = new RobotContainer();
-    System.out.println("I have assumed control of the Riverbot code base.");
+    // We need to invert one side of the drivetrain so that positive voltages
+    // result in both sides moving forward. Depending on how your robot's
+    // gearbox is constructed, you might have to invert the left side instead.
+    rightyA.setInverted(true);
+    rightyB.setInverted(true);
+    horn.set(false);
+
+    // Initializes the cameras (uses a special UI that we do not have)
+    cam = NetworkTableInstance.getDefault().getTable("").getEntry("CameraSelection");
+    fronty = CameraServer.startAutomaticCapture(0);
+    reary = CameraServer.startAutomaticCapture(1);
   }
 
-  /**
-   * This function is called every 20 ms, no matter the mode. Use this for items like diagnostics
-   * that you want ran during disabled, autonomous, teleoperated and test.
-   *
-   * <p>This runs after the mode specific periodic functions, but before LiveWindow and
-   * SmartDashboard integrated updating.
-   */
-  @Override
-  public void robotPeriodic() {
-    // Runs the Scheduler.  This is responsible for polling buttons, adding newly-scheduled
-    // commands, running already-scheduled commands, removing finished or interrupted commands,
-    // and running subsystem periodic() methods.  This must be called from the robot's periodic
-    // block in order for anything in the Command-based framework to work.
-    CommandScheduler.getInstance().run();
-  }
-
-  /** This function is called once each time the robot enters Disabled mode. */
-  @Override
-  public void disabledInit() {}
-
-  @Override
-  public void disabledPeriodic() {}
-
-  /** This autonomous runs the autonomous command selected by your {@link RobotContainer} class. */
+  /** This function is run once each time the robot enters autonomous mode. */
   @Override
   public void autonomousInit() {
-    m_autonomousCommand = m_robotContainer.getAutonomousCommand();
-
-    // schedule the autonomous command (example)
-    if (m_autonomousCommand != null) {
-      m_autonomousCommand.schedule();
-    }
+    m_timer.reset();
+    m_timer.start();
   }
 
   /** This function is called periodically during autonomous. */
   @Override
-  public void autonomousPeriodic() {}
-
-  @Override
-  public void teleopInit() {
-    // This makes sure that the autonomous stops running when
-    // teleop starts running. If you want the autonomous to
-    // continue until interrupted by another command, remove
-    // this line or comment it out.
-    if (m_autonomousCommand != null) {
-      m_autonomousCommand.cancel();
-    }
+  public void autonomousPeriodic() {
+    return;
   }
 
-  /** This function is called periodically during operator control. */
-  @Override
-  public void teleopPeriodic() {}
+  public void setLeds(int red, int green) {
+    for (var i = 0; i < ledBuffT.getLength()/2; i++) {
+      // Sets the specified LED to the RGB values for red
+      // ledBuff.setRGB(i, 255, 0, 0);
+      ledBuffT.setRGB(i, red, green, 0);
+      ledBuffT.setRGB(i+ledBuffT.getLength()/2, green,red, 0);
+    }
+   ledsT.setData(ledBuffT);
+  }
 
+  /**
+   * This function is called once each time the robot enters teleoperated mode.
+   */
+  @Override
+  public void teleopInit() {
+    // m_robotDrive.arcadeDrive(0.5, 0.0);
+    // Channel 1 is Left stick
+    stick.setXChannel(1);
+    // Channel 3 is RT
+    stick.setZChannel(3);
+    // Channel 5 is Rightstick
+    stick.setYChannel(5);
+
+    // deprecated?
+    lcal = pct(stick.getX(), 0);
+    rcal = pct(stick.getY(), 0);
+
+    ledsT.setLength(ledBuffT.getLength());
+    ledsT.setData(ledBuffT);
+    ledsT.start();
+  }
+
+  public int pct(double raw, int cal) {
+    return (int) (raw * throttle * 1.0) - cal;
+  }
+
+  /*
+   * Convert the dpad POV input to either +1/0/-1.
+   */
+  public int povToDirection() {
+    int pov = stick.getPOV();
+    // this gives upish case from d-pad throttle input
+    if (pov > stickDirectlyLeft || (pov > -1 && pov < stickDirectlyRight)) {
+      return +1;
+    }
+    // this gives downish case
+    if (pov > stickDirectlyRight && pov < stickDirectlyLeft) {
+      return -1;
+    }
+    return 0;
+  }
+
+  /**
+   * This function is called periodically during teleoperated mode.
+   */
+  @Override
+  public void teleopPeriodic() {
+    basket.set(ControlMode.PercentOutput, (stick.getRawAxis(LEFT_TRIGGER) / 2) - (stick.getRawAxis(RIGHT_TRIGGER) / 2));
+
+    if (stick.getRawButtonPressed(1)) {
+      is_reverse = !is_reverse;
+      System.out.println("here");
+    }
+
+    horn.set(stick.getRawButton(2));
+
+    if (is_reverse == true) {
+      setLeds(255, 0);
+      cam.setString(reary.getName());
+      ltarget = -1 * pct(stick.getX(), 0);
+      rtarget = -1 * pct(stick.getY(), 0);
+    } else {
+      setLeds(0, 255);
+      cam.setString(fronty.getName());
+      ltarget = pct(stick.getX(), 0);
+      rtarget = pct(stick.getY(), 0);
+    }
+    System.out.printf("Left: %f, Right: %f\n", stick.getRawAxis(2), stick.getRawAxis(3));
+
+    int currentPov = povToDirection();
+    // dpad up increases throttle, dpad down decreases
+    if (currentPov != previousPov) {
+      if (currentPov == 0) {
+        previousPov = currentPov;
+      } else if (currentPov == +1) {
+        throttle = throttle + changeInThrottle;
+        if (throttle > maxValue) {
+          throttle = maxValue;
+        }
+        previousPov = currentPov;
+      } else if (currentPov == -1) {
+        throttle = throttle - changeInThrottle;
+        if (throttle < minValue) {
+          throttle = minValue;
+        }
+        previousPov = currentPov;
+      }
+      System.out.printf("throttle = %d\n", throttle);
+    }
+    //int ltarget = pct(stick.getX(), 0);
+   // int rtarget = pct(stick.getY(), 0);
+
+    // steps motor power to input
+    if (lout < ltarget) {
+      lout += throttleStep;
+      if (lout > ltarget) {
+        lout = ltarget;
+      }
+    } else if (lout > ltarget) {
+      lout -= throttleStep;
+      if (lout < ltarget) {
+        lout = ltarget;
+      }
+    }
+    if (rout < rtarget) {
+      rout += throttleStep;
+      if (rout > rtarget) {
+        rout = rtarget;
+      }
+    } else if (rout > rtarget) {
+      rout -= throttleStep;
+      if (rout < rtarget) {
+        rout = rtarget;
+      }
+    }
+
+    if (stick.getRawButton(3) && stick.getRawButton(4)) {
+      STOP = true;
+    }
+    if (currentPov != 0){
+      STOP = false;
+    }
+
+    if (STOP == true){
+      rout = 0;
+      lout = 0;
+    }
+    
+    // converts output to a decimal percent to prevent the motors from having only o
+    // and 100 power
+    leftyA.set(ControlMode.PercentOutput, 1.0 * lout / 100.0);
+    leftyB.set(ControlMode.PercentOutput, 1.0 * lout / 100.0);
+    rightyA.set(ControlMode.PercentOutput, 1.0 * rout / 100.0);
+    rightyB.set(ControlMode.PercentOutput, 1.0 * rout / 100.0);
+  }
+
+  /** This function is called once each time the robot enters test mode. */
   @Override
   public void testInit() {
-    // Cancels all running commands at the start of test mode.
-    CommandScheduler.getInstance().cancelAll();
   }
 
   /** This function is called periodically during test mode. */
   @Override
-  public void testPeriodic() {}
-
-  /** This function is called once when the robot is first started up. */
-  @Override
-  public void simulationInit() {}
-
-  /** This function is called periodically whilst in simulation. */
-  @Override
-  public void simulationPeriodic() {}
+  public void testPeriodic() {
+  }
 }

--- a/robot/2023/src/main/java/frc/robot/Robot.java
+++ b/robot/2023/src/main/java/frc/robot/Robot.java
@@ -28,6 +28,7 @@ public class Robot extends TimedRobot {
     // Instantiate our RobotContainer.  This will perform all our button bindings, and put our
     // autonomous chooser on the dashboard.
     m_robotContainer = new RobotContainer();
+    System.out.println("I have assumed control of the Riverbot code base.");
   }
 
   /**

--- a/robot/2023/src/main/java/frc/robot/Robot.java
+++ b/robot/2023/src/main/java/frc/robot/Robot.java
@@ -27,11 +27,9 @@ import edu.wpi.first.networktables.NetworkTableInstance;
 public class Robot extends TimedRobot {
   private static final int LEFT_TRIGGER = 2;
   private static final int RIGHT_TRIGGER = 3;
-  TalonSRX leftyA = new TalonSRX(0);
-  TalonSRX leftyB = new TalonSRX(1);
-  TalonSRX rightyA = new TalonSRX(2);
-  TalonSRX rightyB = new TalonSRX(3);
-  VictorSPX basket = new VictorSPX(4);
+  VictorSPX lefty = new VictorSPX(0);
+  VictorSPX righty = new VictorSPX(1);
+
   AddressableLED ledsT = new AddressableLED(0);
   AddressableLEDBuffer ledBuffT = new AddressableLEDBuffer(30);
   
@@ -73,8 +71,8 @@ public class Robot extends TimedRobot {
     // We need to invert one side of the drivetrain so that positive voltages
     // result in both sides moving forward. Depending on how your robot's
     // gearbox is constructed, you might have to invert the left side instead.
-    rightyA.setInverted(true);
-    rightyB.setInverted(true);
+    righty.setInverted(true);
+    //rightyB.setInverted(true);
     horn.set(false);
 
     // Initializes the cameras (uses a special UI that we do not have)
@@ -153,7 +151,7 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void teleopPeriodic() {
-    basket.set(ControlMode.PercentOutput, (stick.getRawAxis(LEFT_TRIGGER) / 2) - (stick.getRawAxis(RIGHT_TRIGGER) / 2));
+   // basket.set(ControlMode.PercentOutput, (stick.getRawAxis(LEFT_TRIGGER) / 2) - (stick.getRawAxis(RIGHT_TRIGGER) / 2));
 
     if (stick.getRawButtonPressed(1)) {
       is_reverse = !is_reverse;
@@ -236,10 +234,8 @@ public class Robot extends TimedRobot {
     
     // converts output to a decimal percent to prevent the motors from having only o
     // and 100 power
-    leftyA.set(ControlMode.PercentOutput, 1.0 * lout / 100.0);
-    leftyB.set(ControlMode.PercentOutput, 1.0 * lout / 100.0);
-    rightyA.set(ControlMode.PercentOutput, 1.0 * rout / 100.0);
-    rightyB.set(ControlMode.PercentOutput, 1.0 * rout / 100.0);
+    lefty.set(ControlMode.PercentOutput, 1.0 * lout / 100.0);
+    righty.set(ControlMode.PercentOutput, 1.0 * rout / 100.0);
   }
 
   /** This function is called once each time the robot enters test mode. */

--- a/robot/2023/vendordeps/Phoenix.json
+++ b/robot/2023/vendordeps/Phoenix.json
@@ -1,0 +1,423 @@
+{
+    "fileName": "Phoenix.json",
+    "name": "CTRE-Phoenix (v5)",
+    "version": "5.30.3",
+    "frcYear": 2023,
+    "uuid": "ab676553-b602-441f-a38d-f1296eff6537",
+    "mavenUrls": [
+        "https://maven.ctr-electronics.com/release/"
+    ],
+    "jsonUrl": "https://maven.ctr-electronics.com/release/com/ctre/phoenix/Phoenix5-frc2023-latest.json",
+    "javaDependencies": [
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "api-java",
+            "version": "5.30.3"
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "wpiapi-java",
+            "version": "5.30.3"
+        }
+    ],
+    "jniDependencies": [
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "cci",
+            "version": "5.30.3",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxathena"
+            ],
+            "simMode": "hwsim"
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "cci-sim",
+            "version": "5.30.3",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenixpro",
+            "artifactId": "tools",
+            "version": "23.0.2",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxathena"
+            ],
+            "simMode": "hwsim"
+        },
+        {
+            "groupId": "com.ctre.phoenixpro.sim",
+            "artifactId": "tools-sim",
+            "version": "23.0.2",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenixpro.sim",
+            "artifactId": "simTalonSRX",
+            "version": "23.0.2",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenixpro.sim",
+            "artifactId": "simTalonFX",
+            "version": "23.0.2",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenixpro.sim",
+            "artifactId": "simVictorSPX",
+            "version": "23.0.2",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenixpro.sim",
+            "artifactId": "simPigeonIMU",
+            "version": "23.0.2",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenixpro.sim",
+            "artifactId": "simCANCoder",
+            "version": "23.0.2",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenixpro.sim",
+            "artifactId": "simProTalonFX",
+            "version": "23.0.2",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenixpro.sim",
+            "artifactId": "simProCANcoder",
+            "version": "23.0.2",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenixpro.sim",
+            "artifactId": "simProPigeon2",
+            "version": "23.0.2",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        }
+    ],
+    "cppDependencies": [
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "wpiapi-cpp",
+            "version": "5.30.3",
+            "libName": "CTRE_Phoenix_WPI",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxathena"
+            ],
+            "simMode": "hwsim"
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "api-cpp",
+            "version": "5.30.3",
+            "libName": "CTRE_Phoenix",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxathena"
+            ],
+            "simMode": "hwsim"
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "cci",
+            "version": "5.30.3",
+            "libName": "CTRE_PhoenixCCI",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxathena"
+            ],
+            "simMode": "hwsim"
+        },
+        {
+            "groupId": "com.ctre.phoenixpro",
+            "artifactId": "tools",
+            "version": "23.0.2",
+            "libName": "CTRE_PhoenixTools",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxathena"
+            ],
+            "simMode": "hwsim"
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "wpiapi-cpp-sim",
+            "version": "5.30.3",
+            "libName": "CTRE_Phoenix_WPISim",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "api-cpp-sim",
+            "version": "5.30.3",
+            "libName": "CTRE_PhoenixSim",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "cci-sim",
+            "version": "5.30.3",
+            "libName": "CTRE_PhoenixCCISim",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenixpro.sim",
+            "artifactId": "tools-sim",
+            "version": "23.0.2",
+            "libName": "CTRE_PhoenixTools_Sim",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenixpro.sim",
+            "artifactId": "simTalonSRX",
+            "version": "23.0.2",
+            "libName": "CTRE_SimTalonSRX",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenixpro.sim",
+            "artifactId": "simTalonFX",
+            "version": "23.0.2",
+            "libName": "CTRE_SimTalonFX",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenixpro.sim",
+            "artifactId": "simVictorSPX",
+            "version": "23.0.2",
+            "libName": "CTRE_SimVictorSPX",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenixpro.sim",
+            "artifactId": "simPigeonIMU",
+            "version": "23.0.2",
+            "libName": "CTRE_SimPigeonIMU",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenixpro.sim",
+            "artifactId": "simCANCoder",
+            "version": "23.0.2",
+            "libName": "CTRE_SimCANCoder",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenixpro.sim",
+            "artifactId": "simProTalonFX",
+            "version": "23.0.2",
+            "libName": "CTRE_SimProTalonFX",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenixpro.sim",
+            "artifactId": "simProCANcoder",
+            "version": "23.0.2",
+            "libName": "CTRE_SimProCANcoder",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenixpro.sim",
+            "artifactId": "simProPigeon2",
+            "version": "23.0.2",
+            "libName": "CTRE_SimProPigeon2",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        }
+    ]
+}


### PR DESCRIPTION
"https://maven.ctr-electronics.com/release/com/ctre/phoenix/Phoenix5-frc2023-latest.json" may be necessary to download under:
"Manage Vendor Libraries" -> "Install new libraries (online)
I assume it will be included in this merge though

Added:
-Code from 2022's "Robot.java" into our "Robot.java" file
Altered:
-Switched "TalonSRX" motor code with "VictorSPX" motor controller code, and shifted from four motor controller to two (Build team only used two motor controllers this year, as opposed to the previous four, so the code was altered to align with that)