### PR TITLE
Some Accelerometer Updates & Working Screw Drive

### DIFF
--- a/robot/2023/src/main/java/frc/robot/Robot.java
+++ b/robot/2023/src/main/java/frc/robot/Robot.java
@@ -7,7 +7,7 @@ package frc.robot;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.I2C.Port;
-import edu.wpi.first.wpilibj.XboxController.Button;
+
 import edu.wpi.first.wpilibj.I2C;
 import edu.wpi.first.wpilibj.interfaces.Accelerometer;
 import edu.wpi.first.wpilibj.motorcontrol.Spark;
@@ -20,8 +20,6 @@ import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import com.ctre.phoenix.motorcontrol.VictorSPXControlMode;
 import com.ctre.phoenix.motorcontrol.can.VictorSPX;
 import edu.wpi.first.wpilibj.Joystick;
-import com.revrobotics.CANSparkMax;
-import com.revrobotics.CANSparkMaxLowLevel.MotorType;
 
 import edu.wpi.first.cameraserver.CameraServer;
 import edu.wpi.first.cscore.UsbCamera;
@@ -44,7 +42,7 @@ public class Robot extends TimedRobot {
   VictorSPX rightMotorControllerOne = new VictorSPX(7);
   VictorSPX rightMotorControllerTwo = new VictorSPX(8);
   Spark sparkScoringMechanismMotor = new Spark(1);
-  Spark ScrewDriveMotor = new Spark(2);
+  Spark screwDriveMotor = new Spark(2);
 
   private RobotContainer m_robotContainer;
 
@@ -152,8 +150,8 @@ public class Robot extends TimedRobot {
     leftMotorControllerTwo.set(VictorSPXControlMode.PercentOutput,stick.getRawAxis(LEFT_STICK_VERTICAL));
     rightMotorControllerOne.set(VictorSPXControlMode.PercentOutput,stick.getRawAxis(RIGHT_STICK_VERTICAL));
     rightMotorControllerTwo.set(VictorSPXControlMode.PercentOutput,stick.getRawAxis(RIGHT_STICK_VERTICAL));
-    sparkScoringMechanismMotor.set(RightBumperOut - LeftBumperOut);
-    ScrewDriveMotor.set(RightTriggerOut - LeftTriggerOut);
+    sparkScoringMechanismMotor.set(RightTriggerOut - LeftTriggerOut);
+    screwDriveMotor.set(RightBumperOut - LeftBumperOut);
     //and should probably be replaced with a timer-
     double previousXAccelerometer = accelerometer.getX();
     double previousYAccelerometer = accelerometer.getY();

--- a/robot/2023/src/main/java/frc/robot/Robot.java
+++ b/robot/2023/src/main/java/frc/robot/Robot.java
@@ -12,8 +12,6 @@ import edu.wpi.first.wpilibj.I2C;
 import edu.wpi.first.wpilibj.interfaces.Accelerometer;
 import edu.wpi.first.wpilibj.motorcontrol.Spark;
 import edu.wpi.first.wpilibj.BuiltInAccelerometer;
-
-
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 
@@ -41,8 +39,8 @@ public class Robot extends TimedRobot {
   VictorSPX leftMotorControllerTwo = new VictorSPX(6);
   VictorSPX rightMotorControllerOne = new VictorSPX(7);
   VictorSPX rightMotorControllerTwo = new VictorSPX(8);
-  //channel 0 is broken on our current RoboRio.  Would not recommend trying to use it
-  Spark sparkScoringMechanismMotor = new Spark(1);
+  //PWM channel 0 is broken on our current RoboRio.  Would not recommend trying to use it
+  Spark brushElevator = new Spark(1);
   Spark screwDriveMotor = new Spark(2);
   
   private RobotContainer m_robotContainer;
@@ -61,8 +59,8 @@ public class Robot extends TimedRobot {
 
   final int LEFT_TRIGGER = 2;
   final int RIGHT_TRIGGER = 3;
-  final int LEFT_BUMPER = 2;
-  final int RIGHT_BUMPER = 3;
+  final int LEFT_BUMPER = 5;
+  final int RIGHT_BUMPER = 6;
   UsbCamera parkingCamera;
   NetworkTableEntry camera;
 
@@ -149,16 +147,27 @@ public class Robot extends TimedRobot {
 
     double RightTriggerOut = stick.getRawAxis(RIGHT_TRIGGER);
     double LeftTriggerOut = stick.getRawAxis(LEFT_TRIGGER);
-    double RightBumperOut = stick.getRawAxis(RIGHT_BUMPER);
-    double LeftBumperOut = stick.getRawAxis(LEFT_BUMPER);
 
     //These all connect to seperate motors and actually control the output.  (Makes wheels, screwdrive, ect, GO)
     leftMotorControllerOne.set(VictorSPXControlMode.PercentOutput,stick.getRawAxis(LEFT_STICK_VERTICAL));
     leftMotorControllerTwo.set(VictorSPXControlMode.PercentOutput,stick.getRawAxis(LEFT_STICK_VERTICAL));
     rightMotorControllerOne.set(VictorSPXControlMode.PercentOutput,stick.getRawAxis(RIGHT_STICK_VERTICAL));
     rightMotorControllerTwo.set(VictorSPXControlMode.PercentOutput,stick.getRawAxis(RIGHT_STICK_VERTICAL));
-    sparkScoringMechanismMotor.set(RightTriggerOut - LeftTriggerOut);
-    screwDriveMotor.set(RightBumperOut - LeftBumperOut);
+    brushElevator.set(RightTriggerOut - LeftTriggerOut);
+
+    if(stick.getRawButton(RIGHT_BUMPER))
+    {
+      screwDriveMotor.set(1);
+    }
+    else if(stick.getRawButton(LEFT_BUMPER))
+    {
+      screwDriveMotor.set(-1);
+    }
+    else
+    {
+      screwDriveMotor.set(0);
+    }
+    
 
     double previousXAccelerometer = accelerometer.getX();
     double previousYAccelerometer = accelerometer.getY();

--- a/robot/2023/src/main/java/frc/robot/Robot.java
+++ b/robot/2023/src/main/java/frc/robot/Robot.java
@@ -18,6 +18,7 @@ import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import com.ctre.phoenix.motorcontrol.VictorSPXControlMode;
 import com.ctre.phoenix.motorcontrol.can.VictorSPX;
 import edu.wpi.first.wpilibj.Joystick;
+import com.revrobotics.CANSparkMax;
 
 import edu.wpi.first.cameraserver.CameraServer;
 import edu.wpi.first.cscore.UsbCamera;
@@ -35,9 +36,12 @@ public class Robot extends TimedRobot {
   private Command m_autonomousCommand;
 
   private final Joystick stick = new Joystick(0);
-
-  VictorSPX leftMotorController = new VictorSPX(2);
-  VictorSPX rightMotorController = new VictorSPX(1);
+  //Still need tested to see which motor controllers are which
+  VictorSPX leftMotorControllerOne = new VictorSPX(5);
+  VictorSPX leftMotorControllerTwo = new VictorSPX(6);
+  VictorSPX rightMotorControllerOne = new VictorSPX(7);
+  VictorSPX rightMotorControllerTwo = new VictorSPX(8);
+  //Screw drive will no longer be a VictorSPX, shift to new Talon
   VictorSPX screwDriveMotorController = new VictorSPX(3);
   private RobotContainer m_robotContainer;
 
@@ -47,7 +51,7 @@ public class Robot extends TimedRobot {
   Accelerometer accelerometer = new BuiltInAccelerometer();
   
   final int LEFT_STICK_VERTICAL = 1;
-  final int RIGHT_STICK_VERTICAL = 5;
+  final int RIGHT_STICK_VERTICAL = 3;
   final int LEFT_TRIGGER = 2;
   final int RIGHT_TRIGGER = 3;
 
@@ -120,7 +124,8 @@ public class Robot extends TimedRobot {
 
     stick.setXChannel(LEFT_STICK_VERTICAL);
     stick.setYChannel(RIGHT_STICK_VERTICAL);
-    leftMotorController.setInverted(true);
+    leftMotorControllerOne.setInverted(true);
+    leftMotorControllerTwo.setInverted(true);
 
     gyro = new I2C(onBoard, gyroAdress);
     gyro.transaction(new byte[] {0x6B, 0x0}, 2, new byte[] {}, 0);
@@ -135,8 +140,10 @@ public class Robot extends TimedRobot {
     double RightTriggerOut = stick.getRawAxis(RIGHT_TRIGGER) * 0.8;
     double LeftTriggerOut = stick.getRawAxis(LEFT_TRIGGER) * 0.8;
 
-    leftMotorController.set(VictorSPXControlMode.PercentOutput,stick.getRawAxis(LEFT_STICK_VERTICAL));
-    rightMotorController.set(VictorSPXControlMode.PercentOutput,stick.getRawAxis(RIGHT_STICK_VERTICAL));
+    leftMotorControllerOne.set(VictorSPXControlMode.PercentOutput,stick.getRawAxis(LEFT_STICK_VERTICAL));
+    leftMotorControllerTwo.set(VictorSPXControlMode.PercentOutput,stick.getRawAxis(LEFT_STICK_VERTICAL));
+    rightMotorControllerOne.set(VictorSPXControlMode.PercentOutput,stick.getRawAxis(RIGHT_STICK_VERTICAL));
+    rightMotorControllerTwo.set(VictorSPXControlMode.PercentOutput,stick.getRawAxis(RIGHT_STICK_VERTICAL));
     screwDriveMotorController.set(VictorSPXControlMode.PercentOutput, RightTriggerOut - LeftTriggerOut);
     
     //Updates console whenever a value in accelerometer changes, though it's still too fast
@@ -157,7 +164,7 @@ public class Robot extends TimedRobot {
       System.out.println(accelerometer.getZ());
     }
   }
- 
+  
   @Override
   public void testInit() {
     // Cancels all running commands at the start of test mode.

--- a/robot/2023/src/main/java/frc/robot/Robot.java
+++ b/robot/2023/src/main/java/frc/robot/Robot.java
@@ -42,7 +42,7 @@ public class Robot extends TimedRobot {
   VictorSPX leftMotorControllerTwo = new VictorSPX(6);
   VictorSPX rightMotorControllerOne = new VictorSPX(7);
   VictorSPX rightMotorControllerTwo = new VictorSPX(8);
-  Spark sparkScrewDriveMotorController = new Spark(1);
+  Spark sparkScoringMechanismMotor = new Spark(1);
 
   private RobotContainer m_robotContainer;
 
@@ -147,7 +147,7 @@ public class Robot extends TimedRobot {
     leftMotorControllerTwo.set(VictorSPXControlMode.PercentOutput,stick.getRawAxis(LEFT_STICK_VERTICAL));
     rightMotorControllerOne.set(VictorSPXControlMode.PercentOutput,stick.getRawAxis(RIGHT_STICK_VERTICAL));
     rightMotorControllerTwo.set(VictorSPXControlMode.PercentOutput,stick.getRawAxis(RIGHT_STICK_VERTICAL));
-    sparkScrewDriveMotorController.set(RightTriggerOut - LeftTriggerOut);
+    sparkScoringMechanismMotor.set(RightTriggerOut - LeftTriggerOut);
     if(RightTriggerOut > .01)
     {
       System.out.println("RIGHT trigger works");

--- a/robot/2023/src/main/java/frc/robot/Robot.java
+++ b/robot/2023/src/main/java/frc/robot/Robot.java
@@ -5,7 +5,7 @@
 package frc.robot;
 
 import edu.wpi.first.wpilibj.TimedRobot;
-
+import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.I2C.Port;
 import edu.wpi.first.wpilibj.I2C;
 import edu.wpi.first.wpilibj.interfaces.Accelerometer;
@@ -125,6 +125,7 @@ public class Robot extends TimedRobot {
     gyro = new I2C(onBoard, gyroAdress);
     gyro.transaction(new byte[] {0x6B, 0x0}, 2, new byte[] {}, 0);
     gyro.transaction(new byte[] {0x1B, 0x10},  2, new byte[] {}, 0);
+    System.out.println("debug plz");
   }
 
   /** This function is called periodically during operator control. */
@@ -138,9 +139,23 @@ public class Robot extends TimedRobot {
     rightMotorController.set(VictorSPXControlMode.PercentOutput,stick.getRawAxis(RIGHT_STICK_VERTICAL));
     screwDriveMotorController.set(VictorSPXControlMode.PercentOutput, RightTriggerOut - LeftTriggerOut);
     
-    System.out.println(accelerometer.getX());
-    System.out.println(accelerometer.getY());
-    System.out.println(accelerometer.getZ());
+    //Updates console whenever a value in accelerometer changes, though it's still too fast
+    //and should probably be replaced with a timer
+    double previousXAccelerometer = accelerometer.getX();
+    double previousYAccelerometer = accelerometer.getY();
+    double previousZAccelerometer = accelerometer.getZ();
+    if(accelerometer.getX() != previousXAccelerometer)
+    {
+      System.out.println(accelerometer.getX());
+    }
+    if(accelerometer.getY() != previousYAccelerometer)
+    {
+      System.out.println(accelerometer.getY());
+    }
+    if(accelerometer.getZ() != previousZAccelerometer)
+    {
+      System.out.println(accelerometer.getZ());
+    }
   }
  
   @Override

--- a/robot/2023/src/main/java/frc/robot/Robot.java
+++ b/robot/2023/src/main/java/frc/robot/Robot.java
@@ -50,9 +50,10 @@ public class Robot extends TimedRobot {
   static final int gyroAdress = 0x68;
   I2C gyro;
   Accelerometer accelerometer = new BuiltInAccelerometer();
-  
+  //These constants set channels for the controller.  On the back of the Logitech controller we use,
+  //there is a switch.  Ensure the switch it set to "X" rather than "D" or the channels will be wrong
   final int LEFT_STICK_VERTICAL = 1;
-  final int RIGHT_STICK_VERTICAL = 3;
+  final int RIGHT_STICK_VERTICAL = 5;
   final int LEFT_TRIGGER = 2;
   final int RIGHT_TRIGGER = 3;
 
@@ -147,6 +148,14 @@ public class Robot extends TimedRobot {
     rightMotorControllerOne.set(VictorSPXControlMode.PercentOutput,stick.getRawAxis(RIGHT_STICK_VERTICAL));
     rightMotorControllerTwo.set(VictorSPXControlMode.PercentOutput,stick.getRawAxis(RIGHT_STICK_VERTICAL));
     sparkScrewDriveMotorController.set(RightTriggerOut - LeftTriggerOut);
+    if(RightTriggerOut > .01)
+    {
+      System.out.println("RIGHT trigger works");
+    }
+    if(LeftTriggerOut > .01)
+    {
+      System.out.println("Left trigger works");
+    }
     
     //Updates console whenever a value in accelerometer changes, though it's still too fast
     //and should probably be replaced with a timer

--- a/robot/2023/src/main/java/frc/robot/Robot.java
+++ b/robot/2023/src/main/java/frc/robot/Robot.java
@@ -7,6 +7,7 @@ package frc.robot;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.I2C.Port;
+import edu.wpi.first.wpilibj.XboxController.Button;
 import edu.wpi.first.wpilibj.I2C;
 import edu.wpi.first.wpilibj.interfaces.Accelerometer;
 import edu.wpi.first.wpilibj.motorcontrol.Spark;
@@ -43,6 +44,7 @@ public class Robot extends TimedRobot {
   VictorSPX rightMotorControllerOne = new VictorSPX(7);
   VictorSPX rightMotorControllerTwo = new VictorSPX(8);
   Spark sparkScoringMechanismMotor = new Spark(1);
+  Spark ScrewDriveMotor = new Spark(2);
 
   private RobotContainer m_robotContainer;
 
@@ -56,7 +58,8 @@ public class Robot extends TimedRobot {
   final int RIGHT_STICK_VERTICAL = 5;
   final int LEFT_TRIGGER = 2;
   final int RIGHT_TRIGGER = 3;
-
+  final int LEFT_BUMPER = 10;
+  final int RIGHT_BUMPER = 11;
   UsbCamera parkingCamera;
   NetworkTableEntry camera;
 
@@ -140,25 +143,18 @@ public class Robot extends TimedRobot {
   @Override
   public void teleopPeriodic() {
 
-    double RightTriggerOut = stick.getRawAxis(RIGHT_TRIGGER) * 0.8;
-    double LeftTriggerOut = stick.getRawAxis(LEFT_TRIGGER) * 0.8;
+    double RightTriggerOut = stick.getRawAxis(RIGHT_TRIGGER);
+    double LeftTriggerOut = stick.getRawAxis(LEFT_TRIGGER);
+    double RightBumperOut = stick.getRawAxis(RIGHT_BUMPER);
+    double LeftBumperOut = stick.getRawAxis(LEFT_BUMPER);
 
     leftMotorControllerOne.set(VictorSPXControlMode.PercentOutput,stick.getRawAxis(LEFT_STICK_VERTICAL));
     leftMotorControllerTwo.set(VictorSPXControlMode.PercentOutput,stick.getRawAxis(LEFT_STICK_VERTICAL));
     rightMotorControllerOne.set(VictorSPXControlMode.PercentOutput,stick.getRawAxis(RIGHT_STICK_VERTICAL));
     rightMotorControllerTwo.set(VictorSPXControlMode.PercentOutput,stick.getRawAxis(RIGHT_STICK_VERTICAL));
-    sparkScoringMechanismMotor.set(RightTriggerOut - LeftTriggerOut);
-    if(RightTriggerOut > .01)
-    {
-      System.out.println("RIGHT trigger works");
-    }
-    if(LeftTriggerOut > .01)
-    {
-      System.out.println("Left trigger works");
-    }
-    
-    //Updates console whenever a value in accelerometer changes, though it's still too fast
-    //and should probably be replaced with a timer
+    sparkScoringMechanismMotor.set(RightBumperOut - LeftBumperOut);
+    ScrewDriveMotor.set(RightTriggerOut - LeftTriggerOut);
+    //and should probably be replaced with a timer-
     double previousXAccelerometer = accelerometer.getX();
     double previousYAccelerometer = accelerometer.getY();
     double previousZAccelerometer = accelerometer.getZ();

--- a/robot/2023/src/main/java/frc/robot/Robot.java
+++ b/robot/2023/src/main/java/frc/robot/Robot.java
@@ -9,6 +9,7 @@ import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.I2C.Port;
 import edu.wpi.first.wpilibj.I2C;
 import edu.wpi.first.wpilibj.interfaces.Accelerometer;
+import edu.wpi.first.wpilibj.motorcontrol.Spark;
 import edu.wpi.first.wpilibj.BuiltInAccelerometer;
 
 
@@ -19,6 +20,7 @@ import com.ctre.phoenix.motorcontrol.VictorSPXControlMode;
 import com.ctre.phoenix.motorcontrol.can.VictorSPX;
 import edu.wpi.first.wpilibj.Joystick;
 import com.revrobotics.CANSparkMax;
+import com.revrobotics.CANSparkMaxLowLevel.MotorType;
 
 import edu.wpi.first.cameraserver.CameraServer;
 import edu.wpi.first.cscore.UsbCamera;
@@ -36,13 +38,12 @@ public class Robot extends TimedRobot {
   private Command m_autonomousCommand;
 
   private final Joystick stick = new Joystick(0);
-  //Still need tested to see which motor controllers are which
   VictorSPX leftMotorControllerOne = new VictorSPX(5);
   VictorSPX leftMotorControllerTwo = new VictorSPX(6);
   VictorSPX rightMotorControllerOne = new VictorSPX(7);
   VictorSPX rightMotorControllerTwo = new VictorSPX(8);
-  //Screw drive will no longer be a VictorSPX, shift to new Talon
-  VictorSPX screwDriveMotorController = new VictorSPX(3);
+  Spark sparkScrewDriveMotorController = new Spark(1);
+
   private RobotContainer m_robotContainer;
 
   static final Port onBoard = Port.kOnboard;
@@ -70,6 +71,7 @@ public class Robot extends TimedRobot {
 
     camera = NetworkTableInstance.getDefault().getTable("").getEntry("CameraSelection");
     parkingCamera = CameraServer.startAutomaticCapture(0);
+
   }
 
   /**
@@ -144,7 +146,7 @@ public class Robot extends TimedRobot {
     leftMotorControllerTwo.set(VictorSPXControlMode.PercentOutput,stick.getRawAxis(LEFT_STICK_VERTICAL));
     rightMotorControllerOne.set(VictorSPXControlMode.PercentOutput,stick.getRawAxis(RIGHT_STICK_VERTICAL));
     rightMotorControllerTwo.set(VictorSPXControlMode.PercentOutput,stick.getRawAxis(RIGHT_STICK_VERTICAL));
-    screwDriveMotorController.set(VictorSPXControlMode.PercentOutput, RightTriggerOut - LeftTriggerOut);
+    sparkScrewDriveMotorController.set(RightTriggerOut - LeftTriggerOut);
     
     //Updates console whenever a value in accelerometer changes, though it's still too fast
     //and should probably be replaced with a timer

--- a/robot/2023/src/main/java/frc/robot/Robot.java
+++ b/robot/2023/src/main/java/frc/robot/Robot.java
@@ -41,23 +41,28 @@ public class Robot extends TimedRobot {
   VictorSPX leftMotorControllerTwo = new VictorSPX(6);
   VictorSPX rightMotorControllerOne = new VictorSPX(7);
   VictorSPX rightMotorControllerTwo = new VictorSPX(8);
+  //channel 0 is broken on our current RoboRio.  Would not recommend trying to use it
   Spark sparkScoringMechanismMotor = new Spark(1);
   Spark screwDriveMotor = new Spark(2);
-
+  
   private RobotContainer m_robotContainer;
 
   static final Port onBoard = Port.kOnboard;
   static final int gyroAdress = 0x68;
   I2C gyro;
+  
   Accelerometer accelerometer = new BuiltInAccelerometer();
-  //These constants set channels for the controller.  On the back of the Logitech controller we use,
-  //there is a switch.  Ensure the switch it set to "X" rather than "D" or the channels will be wrong
+  //These constants set axes and channels for the controller. The first two are axes. 
+  //On the back of the Logitech controller we use, there is a switch.
+  //Ensure the switch it set to "X" rather than "D" or the channels will be wrong
+  
   final int LEFT_STICK_VERTICAL = 1;
   final int RIGHT_STICK_VERTICAL = 5;
+
   final int LEFT_TRIGGER = 2;
   final int RIGHT_TRIGGER = 3;
-  final int LEFT_BUMPER = 10;
-  final int RIGHT_BUMPER = 11;
+  final int LEFT_BUMPER = 2;
+  final int RIGHT_BUMPER = 3;
   UsbCamera parkingCamera;
   NetworkTableEntry camera;
 
@@ -128,6 +133,7 @@ public class Robot extends TimedRobot {
 
     stick.setXChannel(LEFT_STICK_VERTICAL);
     stick.setYChannel(RIGHT_STICK_VERTICAL);
+    //Left side needs to be inversed to go forwards, otherwise it will work against the right side. (Robot will spin)
     leftMotorControllerOne.setInverted(true);
     leftMotorControllerTwo.setInverted(true);
 
@@ -146,16 +152,18 @@ public class Robot extends TimedRobot {
     double RightBumperOut = stick.getRawAxis(RIGHT_BUMPER);
     double LeftBumperOut = stick.getRawAxis(LEFT_BUMPER);
 
+    //These all connect to seperate motors and actually control the output.  (Makes wheels, screwdrive, ect, GO)
     leftMotorControllerOne.set(VictorSPXControlMode.PercentOutput,stick.getRawAxis(LEFT_STICK_VERTICAL));
     leftMotorControllerTwo.set(VictorSPXControlMode.PercentOutput,stick.getRawAxis(LEFT_STICK_VERTICAL));
     rightMotorControllerOne.set(VictorSPXControlMode.PercentOutput,stick.getRawAxis(RIGHT_STICK_VERTICAL));
     rightMotorControllerTwo.set(VictorSPXControlMode.PercentOutput,stick.getRawAxis(RIGHT_STICK_VERTICAL));
     sparkScoringMechanismMotor.set(RightTriggerOut - LeftTriggerOut);
     screwDriveMotor.set(RightBumperOut - LeftBumperOut);
-    //and should probably be replaced with a timer-
+
     double previousXAccelerometer = accelerometer.getX();
     double previousYAccelerometer = accelerometer.getY();
     double previousZAccelerometer = accelerometer.getZ();
+    //Should probably be replaced with a timer
     if(accelerometer.getX() != previousXAccelerometer)
     {
       System.out.println(accelerometer.getX());

--- a/robot/2023/vendordeps/REVLib.json
+++ b/robot/2023/vendordeps/REVLib.json
@@ -1,0 +1,73 @@
+{
+    "fileName": "REVLib.json",
+    "name": "REVLib",
+    "version": "2023.1.3",
+    "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
+    "mavenUrls": [
+        "https://maven.revrobotics.com/"
+    ],
+    "jsonUrl": "https://software-metadata.revrobotics.com/REVLib-2023.json",
+    "javaDependencies": [
+        {
+            "groupId": "com.revrobotics.frc",
+            "artifactId": "REVLib-java",
+            "version": "2023.1.3"
+        }
+    ],
+    "jniDependencies": [
+        {
+            "groupId": "com.revrobotics.frc",
+            "artifactId": "REVLib-driver",
+            "version": "2023.1.3",
+            "skipInvalidPlatforms": true,
+            "isJar": false,
+            "validPlatforms": [
+                "windowsx86-64",
+                "windowsx86",
+                "linuxarm64",
+                "linuxx86-64",
+                "linuxathena",
+                "linuxarm32",
+                "osxuniversal"
+            ]
+        }
+    ],
+    "cppDependencies": [
+        {
+            "groupId": "com.revrobotics.frc",
+            "artifactId": "REVLib-cpp",
+            "version": "2023.1.3",
+            "libName": "REVLib",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "windowsx86",
+                "linuxarm64",
+                "linuxx86-64",
+                "linuxathena",
+                "linuxarm32",
+                "osxuniversal"
+            ]
+        },
+        {
+            "groupId": "com.revrobotics.frc",
+            "artifactId": "REVLib-driver",
+            "version": "2023.1.3",
+            "libName": "REVLibDriver",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "windowsx86",
+                "linuxarm64",
+                "linuxx86-64",
+                "linuxathena",
+                "linuxarm32",
+                "osxuniversal"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Changed: 
-Left and right motor controllers separated into two motors each ("leftMotorControllerOne" & "leftMotorControllerTwo", etc) as rules state each motor needs its own motor controller
-Made sure to invert BOTH left motor controllers so they don't work against each-other
-Channels to match controller when set to the "X" rather than "D" setting (I don't know the significance of the letters, but the switch is on the back and changing it alters channels)
-VictorSPX motor controller for screw drive (as it is now being used for a wheel motor) switched to a Spark motor controller
-Screw Drive went from triggers (using axis controls mechanism) to bumpers (using buttons as a control mechanism)
Added:
-A Spark motor controller for our pushing/scoring mechanism

-Updated accelerometers to print to console only when a specific X, Y, or Z value changes
Unfortunately, the accelerometer is reporting (extremely) slight changes in value even while stationary, which means this method doesn't quite work.  Currently I can think of two solutions: 1.) Create a timer that refreshes less often than teleopPeriodic or 2.) filter the input to only print when a change is significant (using a set numerical change we value to be so).  